### PR TITLE
fix: `ReferenceError: __filename is not defined`

### DIFF
--- a/src/generate-icon-fonts/svg-to-font.ts
+++ b/src/generate-icon-fonts/svg-to-font.ts
@@ -1,7 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import path from "node:path";
 
 import svgtofont from "svgtofont";
-import { OptionsType } from "../types";
+import { OptionsType } from "../types.js";
 import { log } from "console";
 
 const svgToFont = async (
@@ -11,7 +12,7 @@ const svgToFont = async (
 ) => {
   const { fontName, debug, svgoOptions, outSVGReact, svgicons2svgfont } =
     options;
-  const fileName = __filename;
+  const fileName = fileURLToPath(import.meta.url);
   let lastSlashIndex = fileName.lastIndexOf("\\");
   if (lastSlashIndex === -1) {
     lastSlashIndex = fileName.lastIndexOf("/");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "commonjs",
+    "module": "Node16",
     "declaration": true,
     "outDir": "dist",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
+    "moduleResolution": "Node16",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "Node16",
+    "module": "NodeNext",
     "declaration": true,
     "outDir": "dist",
-    "moduleResolution": "Node16",
+    "moduleResolution": "NodeNext",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
 


### PR DESCRIPTION
```
svgToFont for ./assets/icons/functional/tmp/all
file:///(...)/mono/node_modules/@db-ui/gif/dist/index.mjs:100
  const fileName = __filename;
                   ^

ReferenceError: __filename is not defined
    at svgToFont (file:///(...)/mono/node_modules/@db-ui/gif/dist/index.mjs:100:20)
    at generateIconFonts (file:///(...)/mono/node_modules/@db-ui/gif/dist/index.mjs:391:13)

Node.js v20.16.0

```