### PR TITLE
docs: added a note for required attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ In your app you need to include some of the generated files:
 
 Now you can use your icons with your `font-family: my-name`, e.g.:
 
-Now you can use your icons with your `font-family: my-name`, e.g.:
-
 ```html
 <!--example.html-->
 <i class="my-name">icon_file_name</i>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ In your app you need to include some of the generated files:
 ```
 
 > **_NOTE:_** In case you put the files in a separate folder of your `public` directory be aware to adopt the path in your generated `font-face.css` file: `url("/{YOUR_FOLDER}}/my-name.woff2?t=1698750286189") format("woff2");`
+> > **_NOTE:_** The source files need to provide the following attributes: width, height and viewbox to generate the icon font correctly
+
+Now you can use your icons with your `font-family: my-name`, e.g.:
 
 Now you can use your icons with your `font-family: my-name`, e.g.:
 


### PR DESCRIPTION
The icon font generation fails, if the provided svg has no width, height or viewbox attribute. 