### PR TITLE
refactor: Simplify dependabot configuration for typescript-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,3 @@ updates:
         patterns:
           - "@typescript-eslint*"
           - "typescript-eslint"
-        update-types:
-          - "major"
-          - "minor"


### PR DESCRIPTION
Removed specific update types for typescript-eslint.