### PR TITLE
refactor: pin GitHub Actions

### DIFF
--- a/.github/actions/pnpm-init/action.yml
+++ b/.github/actions/pnpm-init/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: 🆙 Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
         run_install: false
 

--- a/.github/workflows/00-init.yml
+++ b/.github/workflows/00-init.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init

--- a/.github/workflows/00-scan-secrets.yml
+++ b/.github/workflows/00-scan-secrets.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       # https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch
       - name: 🐷 TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.93.8
+        uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3.93.8
         if: ${{ github.event.pull_request != null }} # only scan on pull-requests
         with:
           # Setting base to an empty string scans the entire branch, per TruffleHog OSS advanced usage:

--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init
@@ -19,7 +19,7 @@ jobs:
         run: pnpm build
 
       - name: 🆙 Upload dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build
           path: dist

--- a/.github/workflows/01-lint.yml
+++ b/.github/workflows/01-lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init

--- a/.github/workflows/01-test.yml
+++ b/.github/workflows/01-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⏬ Install fonttools
         run: |

--- a/.github/workflows/02-publish.yml
+++ b/.github/workflows/02-publish.yml
@@ -12,18 +12,18 @@ jobs:
       id-token: write  # Required for OIDC
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
             node-version-file: ".nvmrc"
 
       - name: ⏬ Download dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build
           path: dist

--- a/.github/workflows/99-auto-merge.yml
+++ b/.github/workflows/99-auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: ⏬ Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/99-codeql-analysis.yml
+++ b/.github/workflows/99-codeql-analysis.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔄 Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           languages: ${{ matrix.language }}
 
       - name: 🔨 Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
 
       - name: 🔎 Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2

--- a/.github/workflows/99-dependency-review.yml
+++ b/.github/workflows/99-dependency-review.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: ⏬ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 🔎 Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/99-labeler.yml
+++ b/.github/workflows/99-labeler.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - name: 🏷️ Labeler
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           sync-labels: true

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
   add_labels:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
-      - uses: actions-ecosystem/action-add-assignees@v1
+      - uses: actions-ecosystem/action-add-assignees@a5b84af721c4a621eb9c7a4a95ec20a90d0b88e9 # v1.0.1
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-pnpm-overrides.yml
+++ b/.github/workflows/check-pnpm-overrides.yml
@@ -14,17 +14,17 @@ jobs:
         runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
               with:
                   fetch-depth: 0 # needed for PR creation
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version-file: ".nvmrc"
                   cache: "pnpm"
 
-            - uses: mfranzke/check-pnpm-overrides@v0.0
+            - uses: mfranzke/check-pnpm-overrides@5496a3e14acf6077a6c8dd610634ad51246e5c3d # v0.0.3


### PR DESCRIPTION
We'd like to even also pin our GitHub Actions similar to how we do it for other dependencies like pnpm as well. And we should use SHA references instead of tags to ensure an immutable reference. The versions would still be stored as a comment afterwards, which is best practice and works well with dependabot.

Tags are mutable — anyone with push access to an action's repository can move a tag to point to a different commit, potentially injecting malicious code into your workflows. Pinning to the full commit SHA makes each reference immutable: even if a tag is tampered with, your workflows will continue using the exact code you reviewed and approved. The version comment (`# v6.0.3`) preserves readability and allows Dependabot to detect and propose updates when a new version is released.