### PR TITLE
refactor: Add Node.js setup step to pnpm-init action

### DIFF
--- a/.github/actions/pnpm-init/action.yml
+++ b/.github/actions/pnpm-init/action.yml
@@ -13,6 +13,11 @@ runs:
       shell: bash
       run: pnpm config set store-dir .pnpm-store
 
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+          node-version-file: ".nvmrc"
+
     - name: ⏬ Install pnpm
       shell: bash
       run: pnpm install

--- a/.github/actions/pnpm-init/action.yml
+++ b/.github/actions/pnpm-init/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-          node-version-file: ".nvmrc"
+        node-version-file: ".nvmrc"
 
     - name: ⏬ Install pnpm
       shell: bash

--- a/.github/workflows/02-publish.yml
+++ b/.github/workflows/02-publish.yml
@@ -17,11 +17,6 @@ jobs:
       - name: 🔄 Init PNPM
         uses: ./.github/actions/pnpm-init
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-            node-version-file: ".nvmrc"
-
       - name: ⏬ Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Added Node.js setup step using actions/setup-node. We'll need this in more places than just the currently integrated publish step.